### PR TITLE
Makes the first reference to libev a hyper link to the libev homepage.

### DIFF
--- a/body.tmpl
+++ b/body.tmpl
@@ -133,7 +133,7 @@
 </header>
 
 <blockquote>
-gevent is a concurrency library based around libev.  It provides a clean API for a variety of concurrency and network related tasks.
+gevent is a concurrency library based around <a href="http://software.schmorp.de/pkg/libev.html">libev</a>.  It provides a clean API for a variety of concurrency and network related tasks.
 </blockquote>
 
 {{ body }}


### PR DESCRIPTION
Intent here is to provide a quick link for easy access to more
background on what may be a new term to readers.
