### PR TITLE
Change cooperative subprocess example.

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -972,20 +972,30 @@ As of Gevent 1.0, support has been added for cooperative waiting
 on subprocess.
 
 <pre>
-<code class="python">import gevent
+<code class="python">
+import gevent
 from gevent.subprocess import Popen, PIPE
 
-# Uses a green pipe which is cooperative
-sub = Popen(['uname'], stdout=PIPE)
-read_output = gevent.spawn(sub.stdout.read)
+def cron():
+    while True:
+        print "cron"
+        gevent.sleep(0.2)
 
-output = read_output.join()
-print(output.value)
-<code>
+g = gevent.spawn(cron)
+sub = Popen(['sleep 1; uname'], stdout=PIPE, shell=True)
+out, err = sub.communicate()
+g.kill()
+print out.rstrip()
 </pre>
 
 <pre>
-<code class="python">Linux
+<code class="python">
+cron
+cron
+cron
+cron
+cron
+Linux
 <code>
 </pre>
 


### PR DESCRIPTION
The old example had an issue (as indicated in issue https://github.com/sdiehl/gevent-tutorial/issues/24). This patch provides a new example where we show how a 'cron' greenlet performs a regular task concurrently with waiting for the output of a subprocess.
