### PR TITLE
use zmq.green instead of gevent_zeromq. Fixes #40

### DIFF
--- a/index.html
+++ b/index.html
@@ -1325,9 +1325,9 @@ uses gevent.socket to poll ZeroMQ sockets in a non-blocking
 manner.  You can install gevent-zeromq from PyPi via:  <code>pip install
 gevent-zeromq</code></p>
 <pre><code class="python">
-# Note: Remember to ``pip install pyzmq gevent_zeromq``
+# Note: Remember to ``pip install pyzmq``
 import gevent
-from gevent_zeromq import zmq
+import zmq.green as zmq
 
 # Global Context
 context = zmq.Context()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Markdown==2.1.1
 cogapp==2.3
 Jinja2==2.6
 gevent
-gevent-zeromq
+pyzmq

--- a/tutorial.md
+++ b/tutorial.md
@@ -1165,9 +1165,9 @@ manner.  You can install gevent-zeromq from PyPi via:  ``pip install
 gevent-zeromq``
 
 [[[cog
-# Note: Remember to ``pip install pyzmq gevent_zeromq``
+# Note: Remember to ``pip install pyzmq``
 import gevent
-from gevent_zeromq import zmq
+import zmq.green as zmq
 
 # Global Context
 context = zmq.Context()


### PR DESCRIPTION
PyZMQ ≥ 2.2.0.1 ships with a gevent compatible API as zmq.green.
Besides the fact that using the new, integrated lib is generally
a good idea, gevent_zeromq throws an AttributeError when used
alongside the newer pyzmq.