### PR TITLE
gevent_zeromq has been merged into pyzmq itself

### DIFF
--- a/index.html
+++ b/index.html
@@ -1340,15 +1340,15 @@ distributed applications.</p>
 <p>ZeroMQ provides a variety of socket primitives, the simplest of
 which being a Request-Response socket pair. A socket has two
 methods of interest <code>send</code> and <code>recv</code>, both of which are
-normally blocking operations. But this is remedied by a briliant
-library by <a href="https://github.com/traviscline">Travis Cline</a> which
-uses gevent.socket to poll ZeroMQ sockets in a non-blocking
-manner.  You can install gevent-zeromq from PyPi via:  <code>pip install
-gevent-zeromq</code></p>
+normally blocking operations. But this is remedied by the brilliant
+<a href="https://github.com/tmc/gevent-zeromq">gevent_zeromq</a> library by
+<a href="https://github.com/traviscline">Travis Cline</a>,
+using gevent.socket to poll ZeroMQ sockets in a non-blocking
+manner. <code>gevent_zeromq</code> has now been merged into <code>pyzmq</code> itself
+under the <code>zmq.green</code> module.</p>
 <pre><code class="python">
-# Note: Remember to ``pip install pyzmq gevent_zeromq``
 import gevent
-from gevent_zeromq import zmq
+import zmq.green as zmq
 
 # Global Context
 context = zmq.Context()


### PR DESCRIPTION
I updated the tutorial, which still mentioned the now deprecated ``gevent_zeromq`` as a solution for using ØMQ with the gevent loop.  