### PR TITLE
Rename gevent.coros to gevent.lock

### DIFF
--- a/index.html
+++ b/index.html
@@ -1050,7 +1050,7 @@ releases its acquisition.</p>
 <pre><code class="python">
 from gevent import sleep
 from gevent.pool import Pool
-from gevent.coros import BoundedSemaphore
+from gevent.lock import BoundedSemaphore
 
 sem = BoundedSemaphore(2)
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -888,7 +888,7 @@ releases its acquisition.
 [[[cog
 from gevent import sleep
 from gevent.pool import Pool
-from gevent.coros import BoundedSemaphore
+from gevent.lock import BoundedSemaphore
 
 sem = BoundedSemaphore(2)
 


### PR DESCRIPTION
Module ``gevent.coros`` was replaced by ``gevent.lock`` and was
removed in version 1.2.