### PR TITLE
Fix shutdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -536,7 +536,7 @@ SIGQUIT may hold the program's execution longer than expected.
 This results in so called "zombie processes" which need to be
 killed from outside of the Python interpreter.</p>
 <p>A common pattern is to listen SIGQUIT events on the main program
-and to invoke <code>gevent.shutdown</code> before exit.</p>
+and to invoke <code>gevent.kill</code> or <code>gevent.killall</code> before exit.</p>
 <pre>
 <code class="python">import gevent
 import signal
@@ -545,8 +545,8 @@ def run_forever():
     gevent.sleep(1000)
 
 if __name__ == '__main__':
-    gevent.signal(signal.SIGQUIT, gevent.kill)
     thread = gevent.spawn(run_forever)
+    gevent.signal(signal.SIGQUIT, gevent.kill, thread)
     thread.join()
 </code>
 </pre>

--- a/tutorial.md
+++ b/tutorial.md
@@ -77,7 +77,7 @@ into a collection of subtasks which are scheduled to run simultaneously
 or *asynchronously*, instead of one at a time or *synchronously*. A
 switch between the two subtasks is known as a *context switch*.
 
-A context switch in gevent is done through *yielding*. In this 
+A context switch in gevent is done through *yielding*. In this
 example we have two contexts which yield to each other through invoking
 ``gevent.sleep(0)``.
 
@@ -434,7 +434,7 @@ This results in so called "zombie processes" which need to be
 killed from outside of the Python interpreter.
 
 A common pattern is to listen SIGQUIT events on the main program
-and to invoke ``gevent.shutdown`` before exit.
+and to invoke ``gevent.kill`` or ``gevent.killall`` before exit.
 
 <pre>
 <code class="python">import gevent
@@ -444,8 +444,8 @@ def run_forever():
     gevent.sleep(1000)
 
 if __name__ == '__main__':
-    gevent.signal(signal.SIGQUIT, gevent.kill)
     thread = gevent.spawn(run_forever)
+    gevent.signal(signal.SIGQUIT, gevent.kill, thread)
     thread.join()
 </code>
 </pre>

--- a/tutorial.md
+++ b/tutorial.md
@@ -740,7 +740,7 @@ def worker(name):
 
 def boss():
     """
-    Boss will wait to hand out work until a individual worker is
+    Boss will wait to hand out work until an individual worker is
     free since the maxsize of the task queue is 3.
     """
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -1379,7 +1379,7 @@ WSGIServer(('', 8000), ajax_endpoint).serve_forever()
 
 ## Websockets
 
-Websocket example which requires <a href="https://bitbucket.org/Jeffrey/gevent-websocket/src">gevent-websocket</a>.
+Websocket example which requires <a href="https://bitbucket.org/noppo/gevent-websocket/src">gevent-websocket</a>.
 
 
 <pre>


### PR DESCRIPTION
Original code doesn't work with gevent latest version(1.2.2) any longer. 
`gevent.kill(greenlet, exception=GreenletExit)` requires a greenlet as the first argument.