### PR TITLE
Bug fix on the "Determinism" example

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -251,10 +251,10 @@ multiprocessing pool and compare its results to the one of a gevent pool.
 
 <pre>
 <code class="python">
-import time
+import gevent
 
 def echo(i):
-    time.sleep(0.001)
+    gevent.sleep(0.001)
     return i
 
 # Non Deterministic Process Pool


### PR DESCRIPTION
The use of time.sleep() results in a sequential execution of the echo() tasks in the gevent Pool.
Fixed using gevent.sleep() instead of time.sleep()